### PR TITLE
unsigned: optimizations to improve performance

### DIFF
--- a/zuint/zuint.go
+++ b/zuint/zuint.go
@@ -43,17 +43,15 @@ func SortBYOB(x, buffer []uint) {
 
 	from := x
 	to := buffer[:len(x)]
-	var key uint8 // Current byte value
 
 	for keyOffset := uint(0); keyOffset < bitSize; keyOffset += radix {
-		keyMask := uint(0xFF << keyOffset)
 		var offset [256]int // Keep track of where room is made for byte groups in the buffer
 		sorted := true
 		prev := uint(0)
 
 		for _, elem := range from {
 			// For each elem to sort, fetch the byte at current radix
-			key = uint8((elem & keyMask) >> keyOffset)
+			key := uint8(elem >> keyOffset)
 			// inc count of bytes of this type
 			offset[key]++
 
@@ -79,9 +77,9 @@ func SortBYOB(x, buffer []uint) {
 
 		// Swap values between the buffers by radix
 		for _, elem := range from {
-			key = uint8((elem & keyMask) >> keyOffset) // Get the byte of each element at the radix
-			to[offset[key]] = elem                     // Copy the element depending on byte offsets
-			offset[key]++                              // One less space, move the offset
+			key := uint8(elem >> keyOffset) // Get the byte of each element at the radix
+			to[offset[key]] = elem          // Copy the element depending on byte offsets
+			offset[key]++                   // One less space, move the offset
 		}
 		to, from = from, to
 	}

--- a/zuint32/zuint32.go
+++ b/zuint32/zuint32.go
@@ -42,17 +42,15 @@ func SortBYOB(x, buffer []uint32) {
 
 	from := x
 	to := buffer[:len(x)]
-	var key uint8 // Current byte value
 
 	for keyOffset := uint(0); keyOffset < bitSize; keyOffset += radix {
-		keyMask := uint32(0xFF << keyOffset)
 		var offset [256]int // Keep track of where room is made for byte groups in the buffer
 		sorted := false
 		prev := uint32(0)
 
 		for _, elem := range from {
 			// For each elem to sort, fetch the byte at current radix
-			key = uint8((elem & keyMask) >> keyOffset)
+			key := uint8(elem >> keyOffset)
 			// inc count of bytes of this type
 			offset[key]++
 
@@ -78,7 +76,7 @@ func SortBYOB(x, buffer []uint32) {
 
 		// Swap values between the buffers by radix
 		for _, elem := range from {
-			key = uint8((elem & keyMask) >> keyOffset) // Get the byte of each element at the radix
+			key := uint8(elem >> keyOffset) // Get the byte of each element at the radix
 			to[offset[key]] = elem                     // Copy the element depending on byte offsets
 			offset[key]++                              // One less space, move the offset
 		}

--- a/zuint32/zuint32.go
+++ b/zuint32/zuint32.go
@@ -42,12 +42,11 @@ func SortBYOB(x, buffer []uint32) {
 
 	from := x
 	to := buffer[:len(x)]
-	var key uint8       // Current byte value
-	var offset [256]int // Keep track of where room is made for byte groups in the buffer
+	var key uint8 // Current byte value
 
 	for keyOffset := uint(0); keyOffset < bitSize; keyOffset += radix {
 		keyMask := uint32(0xFF << keyOffset)
-		var counts [256]int // Keep track of the number of elements for each kind of byte
+		var offset [256]int // Keep track of where room is made for byte groups in the buffer
 		sorted := false
 		prev := uint32(0)
 
@@ -55,7 +54,8 @@ func SortBYOB(x, buffer []uint32) {
 			// For each elem to sort, fetch the byte at current radix
 			key = uint8((elem & keyMask) >> keyOffset)
 			// inc count of bytes of this type
-			counts[key]++
+			offset[key]++
+
 			if sorted { // Detect sorted
 				sorted = elem >= prev
 				prev = elem
@@ -69,10 +69,11 @@ func SortBYOB(x, buffer []uint32) {
 			return
 		}
 
-		// Make room for each group of bytes by calculating offset of each
-		offset[0] = 0
-		for i := 1; i < len(offset); i++ {
-			offset[i] = offset[i-1] + counts[i-1]
+		// Find target bucket offsets
+		watermark := offset[0] - offset[0] // Like := 0, but inherits the type.
+		for i, count := range offset {
+			offset[i] = watermark
+			watermark += count
 		}
 
 		// Swap values between the buffers by radix

--- a/zuint64/zuint64.go
+++ b/zuint64/zuint64.go
@@ -43,15 +43,13 @@ func SortBYOB(x, buffer []uint64) {
 	// Each pass processes a byte offset, copying back and forth between slices
 	from := x
 	to := buffer[:len(x)]
-	var key uint8
 
 	for keyOffset := uint(0); keyOffset < bitSize; keyOffset += radix {
-		keyMask := uint64(0xFF << keyOffset) // Current 'digit' to look at
 		var offset [256]int                  // Keep track of where groups start
 		sorted := true                       // Check for already sorted
 		prev := uint64(0)                    // if elem is always >= prev it is already sorted
 		for _, elem := range from {
-			key = uint8((elem & keyMask) >> keyOffset) // fetch the byte at current 'digit'
+			key := uint8(elem >> keyOffset) // fetch the byte at current 'digit'
 			offset[key]++                              // count of elems to put in this digit's bucket
 
 			if sorted { // Detect sorted
@@ -76,7 +74,7 @@ func SortBYOB(x, buffer []uint64) {
 
 		// Rebucket while copying to other buffer
 		for _, elem := range from {
-			key = uint8((elem & keyMask) >> keyOffset) // Get the digit
+			key := uint8(elem >> keyOffset) // Get the digit
 			to[offset[key]] = elem                     // Copy the element to the digit's bucket
 			offset[key]++                              // One less space, move the offset
 		}


### PR DESCRIPTION
The changes are 'trivial' in that they don't change any algorithms or structure of the code.

```console
name               old time/op  new time/op  delta
ZSortUint64T-4     2.71µs ± 7%  2.70µs ±15%     ~     (p=0.684 n=10+10)
ZSorterUint64T-4   2.77µs ± 9%  2.69µs ± 5%     ~     (p=0.243 n=10+9)
ZSortUint64S-4     15.2µs ± 8%  13.2µs ± 5%  -12.98%  (p=0.000 n=10+10)
ZSorterUint64S-4   11.6µs ± 1%   8.8µs ± 0%  -24.39%  (p=0.000 n=10+8)
ZSortUint64M-4     48.9µs ± 7%  45.1µs ± 6%   -7.75%  (p=0.000 n=10+8)
ZSorterUint64M-4   31.6µs ± 0%  28.8µs ± 0%   -8.96%  (p=0.000 n=9+8)
ZSortUint64L-4     68.2ms ± 0%  62.1ms ± 1%   -8.96%  (p=0.000 n=9+10)
ZSorterUint64L-4   68.4ms ± 0%  61.9ms ± 0%   -9.45%  (p=0.000 n=10+9)
ZSortSortedL-4     2.47ms ± 1%  2.41ms ± 1%   -2.51%  (p=0.000 n=10+10)
ZSorterSortedL-4   1.72ms ± 1%  1.66ms ± 1%   -3.32%  (p=0.000 n=10+9)
```